### PR TITLE
Add 'http-server' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "dat.gui": "https://github.com/dataarts/dat.gui/archive/v0.6.5.tar.gz",
     "file-saver": "^1.3.3",
+    "http-server": "^0.10.0",
     "lodash": "^4.5.1",
     "makehuman-js": "^0.1.3",
     "nanobar": "^0.2.1",


### PR DESCRIPTION
On following the commands in the documentation, I got the error `sh: 1: http-server: not found` since `http-server` was not previously installed and not defined as a dependancy in the `package.json` file.

Solved this using `npm install http-server --save` command.